### PR TITLE
Fix darwin build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
           config.allowUnfreePredicate = pkg: nixpkgs.lib.getName pkg == "ngrok";
         };
 
+        darwinDeps = with pkgs; lib.optionals stdenv.isDarwin [
+          darwin.apple_sdk.frameworks.Security
+        ];
+
         app = pkgs.rustPlatform.buildRustPackage {
           pname = "mercury";
           version = "0.0.0";
@@ -19,11 +23,10 @@
           cargoLock.lockFile = ./Cargo.lock;
           nativeBuildInputs = with pkgs; [
             pkg-config
-            darwin.apple_sdk.frameworks.Security
           ];
           buildInputs = with pkgs; [
             openssl
-          ];
+          ] ++ darwinDeps;
         };
 
         img = pkgs.dockerTools.streamLayeredImage {


### PR DESCRIPTION
This dependency is required of us darwin users to build locally

> = note: ld: framework not found Security
  clang-11: error: linker command failed with exit code 1 (use -v to see invocation)