### PR TITLE
Add CI caching

### DIFF
--- a/.github/actions/cargo-cache/action.yml
+++ b/.github/actions/cargo-cache/action.yml
@@ -1,0 +1,18 @@
+name: Cargo registry and build caches
+runs:
+  using: composite
+  steps:
+    - name: Cache registry
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/registry/
+        key: cargo-registry-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}
+    - name: Cache build
+      uses: actions/cache@v3
+      with:
+        path: ./target/
+        key: target-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          target-${{ runner.os }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rm -rf ~/.cargo/
       - uses: cachix/install-nix-action@v22
+      - uses: ./.github/actions/cargo-cache
       - run: nix develop -c cargo check
 
   test:
@@ -32,6 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rm -rf ~/.cargo/
       - uses: cachix/install-nix-action@v22
+      - uses: ./.github/actions/cargo-cache
       - run: nix develop -c cargo test
 
   lint:
@@ -41,6 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rm -rf ~/.cargo/
       - uses: cachix/install-nix-action@v22
+      - uses: ./.github/actions/cargo-cache
       # See: https://github.com/rust-lang/rust-clippy/issues/1209
       - run: RUSTFLAGS="-D warnings" nix develop -c cargo clippy --all-targets
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rm -rf ~/.cargo/
       - uses: cachix/install-nix-action@v22
+      - uses: ./.github/actions/cargo-cache
       - run: |
           nix develop -c cargo doc --no-deps
           rm ./target/doc/.lock


### PR DESCRIPTION
Closes #7.

I've aimed for simplicity but this is a good reference for caching Rust in CI: https://github.com/marketplace/actions/rust-cache

On average the time saved per relevant job from cold to warm is one minute. A CI run with changed code and dependencies should still be expected to run faster, utilising partial caches, albeit with a smaller delta.